### PR TITLE
Add remote-name input to tag workflows and update README

### DIFF
--- a/.github/workflows/add-tag-from-package.yml
+++ b/.github/workflows/add-tag-from-package.yml
@@ -7,12 +7,24 @@ on:
         description: 'Path file containing the version'
         required: true
         type: string
+      remote-name:
+        description: 'Name of repository remote'
+        required: false
+        default: 'origin'
+        type: string
       is-latest:
         description: 'Handle add or update latest tag'
         required: false
         default: true
         type: boolean
+    outputs:
+      tag-exists:
+        description: 'Whether the tag exists on remote'
+        value: ${{ jobs.check-tag-exists.outputs.exists }}
 
+permissions:
+  contents: write
+  
 jobs:
   extract-tag:
     name: Extract Tag from package.json
@@ -60,6 +72,7 @@ jobs:
     uses: JanCodeLab/workflows/.github/workflows/check-tag-exists.yml@latest
     with:
       tag: ${{ needs.extract-tag.outputs.tag }}
+      remote-name: ${{ inputs.remote-name }}
 
   create-tag:
     needs: check-tag-exists
@@ -67,4 +80,5 @@ jobs:
     uses: JanCodeLab/workflows/.github/workflows/create-push-tags.yml@latest
     with:
       tag: ${{ needs.check-tag-exists.outputs.tag }}
+      remote-name: ${{ inputs.remote-name }}
       is-latest: ${{ inputs.is-latest }}

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -7,18 +7,31 @@ on:
         description: 'Tag to add'
         required: true
         type: string
+      remote-name:
+        description: 'Name of repository remote'
+        required: false
+        default: 'origin'
+        type: string
       is-latest:
         description: 'Handle add or update latest tag'
         required: false
         default: true
         type: boolean
+    outputs:
+      tag-exists:
+        description: 'Whether the tag exists on remote'
+        value: ${{ jobs.check-tag-exists.outputs.exists }}
 
+permissions:
+  contents: write
+  
 jobs:
   check-tag-exists:
     name: Check if tag exists
     uses: JanCodeLab/workflows/.github/workflows/check-tag-exists.yml@latest
     with:
       tag: ${{ inputs.tag }}
+      remote-name: ${{ inputs.remote-name }}
 
   create-tag:
     needs: check-tag-exists
@@ -27,4 +40,5 @@ jobs:
     uses: JanCodeLab/workflows/.github/workflows/create-push-tags.yml@latest
     with:
       tag: ${{ needs.check-tag-exists.outputs.tag }}
+      remote-name: ${{ inputs.remote-name }}
       is-latest: ${{ inputs.is-latest }}

--- a/.github/workflows/check-tag-exists.yml
+++ b/.github/workflows/check-tag-exists.yml
@@ -7,6 +7,11 @@ on:
         description: 'Tag to check'
         required: true
         type: string
+      remote-name:
+        description: 'Name of repository remote'
+        required: false
+        default: 'origin'
+        type: string
     outputs:
       exists:
         description: 'Whether the tag exists on remote'
@@ -28,7 +33,7 @@ jobs:
       - name: Check if tag exists on remote
         id: check-tag
         run: |
-          if git ls-remote --tags origin refs/tags/${{ inputs.tag }} | grep -q "refs/tags/${{ inputs.tag }}"; then
+          if git ls-remote --tags ${{ inputs.remote-name }} refs/tags/${{ inputs.tag }} | grep -q "refs/tags/${{ inputs.tag }}"; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "Tag '${{ inputs.tag }}' exists on remote."
           else

--- a/.github/workflows/create-push-tags.yml
+++ b/.github/workflows/create-push-tags.yml
@@ -1,11 +1,18 @@
-name: Create and Push Tag
-
+name: Create and Push Tag to origin
+permissions:
+  contents: write
+  
 on:
   workflow_call:
     inputs:
       tag:
         description: 'Tag to create and push'
         required: true
+        type: string
+      remote-name:
+        description: 'Name of repository remote'
+        required: false
+        default: 'origin'
         type: string
       is-latest:
         description: 'Handle add or update latest tag'
@@ -36,7 +43,7 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           
           # Push tag to remote
-          git push origin "$TAG"
+          git push ${{ inputs.remote-name }} "$TAG"
           
           echo "✅ Successfully created and pushed tag: $TAG"
           
@@ -49,12 +56,12 @@ jobs:
           git tag -d latest 2>/dev/null || true
           
           # Delete the remote latest tag if it exists (don't error if it doesn't)
-          git push origin :refs/tags/latest 2>/dev/null || true
+          git push ${{ inputs.remote-name }} :refs/tags/latest 2>/dev/null || true
           
           # Create a new latest tag pointing to the current HEAD
           git tag -a latest -m "Latest version ${{ inputs.tag }}"
           
           # Push the latest tag
-          git push origin latest
+          git push ${{ inputs.remote-name }} latest
           
           echo "✅ Successfully updated latest tag"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ add-tag:
 ## Changelog
 - v1.2 (latest)
   - Added permissions to workflows
-- v1.1 (latest)
+- v1.1
   - Added tag existence check
 - v1
   - Initial implementation of shared workflow functionalities

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ add-tag:
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `tag` | Tag to add. | Yes | `''` |
+| `remote-name` | Remote name of target repository | No | `origin` |
 | `is-latest` | Set current tag as latest | No | `true` |
 
 # Add tag from package json workflow
@@ -41,9 +42,12 @@ add-tag:
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `version-file` | Tag to add. | Yes | `''` |
+| `remote-name` | Remote name of target repository | No | `origin` |
 | `is-latest` | Set current tag as latest | No | `true` |
 
 ## Changelog
+- v1.2 (latest)
+  - Added permissions to workflows
 - v1.1 (latest)
   - Added tag existence check
 - v1


### PR DESCRIPTION
This pull request introduces several changes to the GitHub workflows to add support for specifying a remote repository name and to enhance the handling of permissions. The most important changes include adding a new input parameter `remote-name`, updating the workflows to use this parameter, and adding permissions configurations.

Enhancements to GitHub workflows:

* [`.github/workflows/add-tag-from-package.yml`](diffhunk://#diff-9e1bbf7d00e24a3b187e39f15b55d745522070f5bcfbeed1829c856930b64734R10-R26): Added `remote-name` input parameter, updated jobs to use this parameter, and added outputs and permissions configurations. [[1]](diffhunk://#diff-9e1bbf7d00e24a3b187e39f15b55d745522070f5bcfbeed1829c856930b64734R10-R26) [[2]](diffhunk://#diff-9e1bbf7d00e24a3b187e39f15b55d745522070f5bcfbeed1829c856930b64734R75-R83)
* [`.github/workflows/add-tag.yml`](diffhunk://#diff-a36f7d26e0c65f69e81cd8885d8ce7e3eebc5dbaf3f32388ded64b2f4812c705R10-R34): Added `remote-name` input parameter, updated jobs to use this parameter, and added outputs and permissions configurations. [[1]](diffhunk://#diff-a36f7d26e0c65f69e81cd8885d8ce7e3eebc5dbaf3f32388ded64b2f4812c705R10-R34) [[2]](diffhunk://#diff-a36f7d26e0c65f69e81cd8885d8ce7e3eebc5dbaf3f32388ded64b2f4812c705R43)
* [`.github/workflows/check-tag-exists.yml`](diffhunk://#diff-67514188e73b1537248489f978dae3c40ef1750a0ba9ac23feb848a373e5ecdaR10-R14): Added `remote-name` input parameter and updated job to use this parameter. [[1]](diffhunk://#diff-67514188e73b1537248489f978dae3c40ef1750a0ba9ac23feb848a373e5ecdaR10-R14) [[2]](diffhunk://#diff-67514188e73b1537248489f978dae3c40ef1750a0ba9ac23feb848a373e5ecdaL31-R36)
* [`.github/workflows/create-push-tags.yml`](diffhunk://#diff-a6030c9de7cd062451bdb105f59b50b18449edc7932b6b85babe201ee18906b7L1-R3): Added `remote-name` input parameter, updated jobs to use this parameter, and added permissions configurations. [[1]](diffhunk://#diff-a6030c9de7cd062451bdb105f59b50b18449edc7932b6b85babe201ee18906b7L1-R3) [[2]](diffhunk://#diff-a6030c9de7cd062451bdb105f59b50b18449edc7932b6b85babe201ee18906b7R12-R16) [[3]](diffhunk://#diff-a6030c9de7cd062451bdb105f59b50b18449edc7932b6b85babe201ee18906b7L39-R46) [[4]](diffhunk://#diff-a6030c9de7cd062451bdb105f59b50b18449edc7932b6b85babe201ee18906b7L52-R65)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22): Updated documentation to include `remote-name` input parameter and added changelog entry for the new version. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R50)